### PR TITLE
feat: add agenda

### DIFF
--- a/presentations/offsite-2018/src/001--agenda.md
+++ b/presentations/offsite-2018/src/001--agenda.md
@@ -1,0 +1,11 @@
+[.autoscale: true]
+
+#Agenda
+
+- Who are we
+- What is OSS
+- Open source skill group
+- Where to contribute
+- Get ready to contribute (for S2)
+
+---


### PR DESCRIPTION
I tried to summarize the agenda a bit otherwise we have too many bullet points.

Current state:

- Who are we [slides about us both]
- What is OSS [slides about intro to OSS]
- Open source skill group [slides about our nice skill group]
- Where to contribute [slide: fine OSS project, call for mantainers]
- Get ready to contribute (for S2) [S2 github orga + configure your account]

I'm actually not happy with the agenda yet, but don't know how to change it. I will have a look later again but if you already have an idea let me know.
FYI we can only add one more bullet point, everything after that is out of screen